### PR TITLE
Updated summit module issue where

### DIFF
--- a/modules/camp_summit/camp_summit.features.yml
+++ b/modules/camp_summit/camp_summit.features.yml
@@ -1,2 +1,1 @@
 bundle: camp
-required: true

--- a/modules/camp_summit/camp_summit.info.yml
+++ b/modules/camp_summit/camp_summit.info.yml
@@ -10,6 +10,7 @@ dependencies:
   - daterange_compact
   - datetime_range
   - field
+  - field_delimiter
   - field_group
   - field_permissions
   - menu_ui

--- a/modules/camp_summit/config/install/core.entity_view_display.node.summit.full.yml
+++ b/modules/camp_summit/config/install/core.entity_view_display.node.summit.full.yml
@@ -12,7 +12,8 @@ dependencies:
     - field.field.node.summit.field_venue
     - node.type.summit
   module:
-    - datetime_range
+    - daterange_compact
+    - field_delimiter
     - text
     - user
 id: node.summit.full
@@ -21,74 +22,53 @@ bundle: summit
 mode: full
 content:
   field_date:
-    weight: 3
-    label: above
+    weight: 0
+    label: inline
     settings:
-      separator: '-'
       format_type: medium
-      timezone_override: ''
     third_party_settings: {  }
-    type: daterange_default
+    type: daterange_compact
     region: content
   field_sponsors:
-    weight: 2
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  field_stick_to_top_of_date:
     weight: 4
-    label: above
+    label: hidden
     settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    type: boolean
-    region: content
-  field_stick_to_top_of_schedule:
-    weight: 5
-    label: above
-    settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    type: boolean
+      view_mode: sponsor_logo
+      link: false
+    third_party_settings:
+      field_delimiter:
+        delimiter: ''
+    type: entity_reference_entity_view
     region: content
   field_summit_description:
-    weight: 6
-    label: above
+    weight: 3
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   field_summit_leaders:
-    weight: 7
-    label: above
+    weight: 2
+    label: inline
     settings:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
     region: content
   field_venue:
-    weight: 8
-    label: above
+    weight: 1
+    label: inline
     settings:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
     region: content
   flag_add_to_schedule:
-    weight: 0
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
-  links:
-    weight: 1
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_stick_to_top_of_date: true
+  field_stick_to_top_of_schedule: true
+  links: true

--- a/modules/camp_summit/config/install/core.entity_view_display.node.summit.teaser.yml
+++ b/modules/camp_summit/config/install/core.entity_view_display.node.summit.teaser.yml
@@ -1,5 +1,5 @@
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
@@ -8,23 +8,50 @@ dependencies:
     - field.field.node.summit.field_stick_to_top_of_date
     - field.field.node.summit.field_stick_to_top_of_schedule
     - field.field.node.summit.field_summit_description
+    - field.field.node.summit.field_summit_leaders
+    - field.field.node.summit.field_venue
     - node.type.summit
   module:
+    - daterange_compact
+    - text
     - user
 id: node.summit.teaser
 targetEntityType: node
 bundle: summit
 mode: teaser
 content:
+  field_date:
+    type: daterange_compact
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      format_type: medium
+    third_party_settings: {  }
+  field_summit_description:
+    type: text_summary_or_trimmed
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+  field_venue:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
   flag_add_to_schedule:
-    weight: 10
+    weight: 3
     region: content
-  links:
-    weight: 100
-    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
-  field_date: true
   field_sponsors: true
   field_stick_to_top_of_date: true
   field_stick_to_top_of_schedule: true
-  field_summit_description: true
+  field_summit_leaders: true
+  links: true

--- a/modules/camp_summit/config/install/views.view.summits.yml
+++ b/modules/camp_summit/config/install/views.view.summits.yml
@@ -491,7 +491,7 @@ display:
           destination: true
           plugin_id: dropbutton
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -507,6 +507,22 @@ display:
     position: 2
     display_options:
       display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  summit_list_page:
+    display_plugin: page
+    id: summit_list_page
+    display_title: Page
+    position: 3
+    display_options:
+      display_extenders: {  }
+      path: summits
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
* Modified `Summit` content type display to remove fields that are only used for data purpose
* Modified `Summit` view and added display for `/summit` page
* Enabled `teaser` display for `Summit` content type